### PR TITLE
Hue & Saturation Shift improvements

### DIFF
--- a/app/lib/createSwatches.ts
+++ b/app/lib/createSwatches.ts
@@ -1,5 +1,12 @@
 import {DEFAULT_PALETTE_CONFIG} from '~/lib/constants'
-import {HSLToHex, hexToHSL, lightnessFromHSLum, luminanceFromHex} from '~/lib/helpers'
+import {
+  HSLToHex,
+  clamp,
+  hexToHSL,
+  lightnessFromHSLum,
+  luminanceFromHex,
+  unsignedModulo,
+} from '~/lib/helpers'
 import {createDistributionValues, createHueScale, createSaturationScale} from '~/lib/scales'
 import type {PaletteConfig} from '~/types'
 
@@ -25,8 +32,8 @@ export function createSwatches(palette: PaletteConfig) {
   const distributionScale = createDistributionValues(lMin, lMax, lightnessValue, valueStop)
 
   const swatches = hueScale.map(({stop}, stopIndex) => {
-    const newH = valueH + hueScale[stopIndex].tweak
-    const newS = valueS + saturationScale[stopIndex].tweak
+    const newH = unsignedModulo(valueH + hueScale[stopIndex].tweak, 360)
+    const newS = clamp(valueS + saturationScale[stopIndex].tweak, 0, 100)
     const newL = useLightness
       ? distributionScale[stopIndex].tweak
       : lightnessFromHSLum(newH, newS, distributionScale[stopIndex].tweak)
@@ -40,9 +47,9 @@ export function createSwatches(palette: PaletteConfig) {
       hex: stop === valueStop ? `#${value.toUpperCase()}` : newHex.toUpperCase(),
       // Used in graphs
       h: newH,
-      hScale: hueScale[stopIndex].tweak,
+      hScale: ((unsignedModulo(hueScale[stopIndex].tweak + 180, 360) - 180) / 180) * 50,
       s: newS,
-      sScale: saturationScale[stopIndex].tweak,
+      sScale: newS - 50,
       l: newL,
     }
   })

--- a/app/lib/helpers.ts
+++ b/app/lib/helpers.ts
@@ -200,3 +200,11 @@ export function arrayObjectDiff(before: PaletteConfig[], current: PaletteConfig[
 
   return changedKeys
 }
+
+export function unsignedModulo(x: number, n: number) {
+  return ((x % n) + n) % n
+}
+
+export function clamp(x: number, min: number, max: number) {
+  return Math.min(Math.max(x, min), max)
+}

--- a/app/lib/scales.ts
+++ b/app/lib/scales.ts
@@ -30,14 +30,7 @@ export function createHueScale(tweak: number = 0, stop: number = DEFAULT_STOP) {
 
   return stops.map((stop) => {
     const diff = Math.abs(stops.indexOf(stop) - index)
-    const tweakValue = tweak ? (diff + 1) * tweak - tweak : 0
-
-    // If tweak value is below 0 or above 360, wrap it around
-    if (tweakValue < 0) {
-      return {stop, tweak: 360 + tweakValue}
-    } else if (tweakValue > 360) {
-      return {stop, tweak: tweakValue - 360}
-    }
+    const tweakValue = tweak ? diff * tweak : 0
 
     return {stop, tweak: tweakValue}
   })


### PR DESCRIPTION
First of all, I love your project!
I noticed some unexpected behaviour with the hue and saturation shifts and thought instead of creating an issue, I might just send you a fix proposal.
Saturation will now be clamped between 0 and 100, while the hue will wrap around at 360. Originally the wrap around for the hue was happening on the tweak value (instead of the hueValue) which meant that negative values would result in a huge positive hue shift. (e.g. -1 would lead to a +359 ontop of the original hue value) and the the saturation would easily get into an invalid range, resulting in a white output color.
I am not sure the way I adjusted the display of the hue and saturation shift is what you want, so feel free to revert the changes to hueScale and saturationScale. The way it's now setup is, that the hue shift graph will display the shift relative to the base hue, with +180 and -180 being the top and bottom of the graph. The saturation shift, is actually just displaying the absolute saturation value, with the top being 100 and the bottom 0. (Maybe it's better to call that graph Saturation instead of Saturation Shift). The problem without this change was that there was an invisible ceiling/floor within the graph because of the clamping, that was a bit unintuitive when tweaking the saturation shift.