### PR TITLE
Clamp lightness values to prevent out of range hex codes and null values

### DIFF
--- a/app/lib/createSwatches.ts
+++ b/app/lib/createSwatches.ts
@@ -1,4 +1,4 @@
-import {DEFAULT_PALETTE_CONFIG} from '~/lib/constants'
+import { DEFAULT_PALETTE_CONFIG } from '~/lib/constants'
 import {
   clamp,
   hexToHSL,
@@ -7,8 +7,8 @@ import {
   luminanceFromHex,
   unsignedModulo,
 } from '~/lib/helpers'
-import {createDistributionValues, createHueScale, createSaturationScale} from '~/lib/scales'
-import type {PaletteConfig} from '~/types'
+import { createDistributionValues, createHueScale, createSaturationScale } from '~/lib/scales'
+import type { PaletteConfig } from '~/types'
 
 export function createSwatches(palette: PaletteConfig) {
   const {value, valueStop} = palette
@@ -34,9 +34,10 @@ export function createSwatches(palette: PaletteConfig) {
   const swatches = hueScale.map(({stop}, stopIndex) => {
     const newH = unsignedModulo(valueH + hueScale[stopIndex].tweak, 360)
     const newS = clamp(valueS + saturationScale[stopIndex].tweak, 0, 100)
-    const newL = useLightness
+    let newL = useLightness
       ? distributionScale[stopIndex].tweak
       : lightnessFromHSLum(newH, newS, distributionScale[stopIndex].tweak)
+    newL = clamp(newL, 0, 100)
 
     const newHex = HSLToHex(newH, newS, newL)
 

--- a/app/lib/helpers.ts
+++ b/app/lib/helpers.ts
@@ -1,5 +1,5 @@
-import {DEFAULT_PALETTE_CONFIG} from '~/lib/constants'
-import type {PaletteConfig} from '~/types'
+import { DEFAULT_PALETTE_CONFIG } from '~/lib/constants'
+import type { PaletteConfig } from '~/types'
 
 export function luminanceFromRGB(r: number, g: number, b: number) {
   // Formula from WCAG 2.0
@@ -92,8 +92,8 @@ export function hexToHSL(H: string) {
 }
 
 export function HSLtoRGB(h: number, s: number, l: number) {
-  s /= 100
-  l /= 100
+  s = clamp(s, 0, 100) / 100
+  l = clamp(l, 0, 100) / 100
 
   const c = (1 - Math.abs(2 * l - 1)) * s
   const x = c * (1 - Math.abs(((h / 60) % 2) - 1))


### PR DESCRIPTION
Fixes #82 

In the UI there is value for a user in being able to set lightness/luminance maximum and minimum values beyond the boundaries permitted by the standard. It allows a palette range to be widened so the ends are not near white/black. 

The end values used in the calculations however need to be clamped in order to prevent hex codes beyond 255. 

In an earlier PR the hue and saturation were clamped. This PR simply applies that to lightness/luminance as well. Additionally adding a safety clamp at the HSLtoRGB helper level. 

Awesome project! Found this to be much more useful than many of the other tailwind palette generators out there. cheers!