### PR TITLE
fix: remove hashes when copying HEX value

### DIFF
--- a/app/components/Palette.tsx
+++ b/app/components/Palette.tsx
@@ -187,6 +187,7 @@ export default function Palette(props: PaletteProps) {
     if (e.currentTarget.name === "name") {
       updateName(newTargetValue);
     } else if (e.currentTarget.name === "value") {
+      newTargetValue = newTargetValue.replace("#", ""); // Remove eventual hashes
       updateValue(newTargetValue);
     }
   };


### PR DESCRIPTION
When copying HEX values from the clipboard, it would be helpful to clean the input by removing the first hash