### PR TITLE
fix(oklch): remove hue from grayscale colors

### DIFF
--- a/app/lib/createDisplayColor.ts
+++ b/app/lib/createDisplayColor.ts
@@ -34,7 +34,7 @@ export function createDisplayColor(
     display = `oklch(${[
       round(l * 100, 2) + `%`,
       round(c, 3),
-      round(h, 2),
+      ...(isNaN(h) ? [] : [round(h, 2)]),
       `/`,
       alphaPlaceholder ? `<alpha-value>` : 1,
     ].join(` `)})`;


### PR DESCRIPTION
Hi again 😅, when converting grayscale colors to oklch, the chroma is 0 while the hue value is undefined (resulting in NaN), so it would be better to omit it in the result:

BEFORE:
![Screenshot 2025-06-12 at 10 17 24](https://github.com/user-attachments/assets/cefbc7a6-e687-4ecb-95b4-97fbfa66ae0d)

AFTER:
![Screenshot 2025-06-12 at 10 19 09](https://github.com/user-attachments/assets/859384ec-0e05-4591-a8a3-2bc9d6c21b83)
