### PR TITLE
Add URL query parameters for output settings

### DIFF
--- a/app/components/Generator.tsx
+++ b/app/components/Generator.tsx
@@ -1,6 +1,7 @@
 import { PlusIcon, SparklesIcon } from "@heroicons/react/24/outline";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import isEqual from "react-fast-compare";
+import { useSearchParams, useNavigate, useLocation } from "react-router";
 
 import { Button } from "~/components/catalyst/button";
 import Demo from "~/components/Demo";
@@ -9,10 +10,10 @@ import Output from "~/components/Output";
 import Palette from "~/components/Palette";
 import type { Block } from "~/components/Prose";
 import { Prose } from "~/components/Prose";
-import { MODES } from "~/lib/constants";
+import { MODES, VERSIONS } from "~/lib/constants";
 import { createRandomPalette } from "~/lib/createRandomPalette";
 import { handleMeta } from "~/lib/meta";
-import type { Mode, PaletteConfig } from "~/types";
+import type { Mode, PaletteConfig, Version } from "~/types";
 
 import Header from "~/components/Header";
 
@@ -23,10 +24,36 @@ type GeneratorProps = {
 };
 
 export default function Generator({ palettes, about, stars }: GeneratorProps) {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const location = useLocation();
   const [palettesState, setPalettesState] = useState(palettes);
   const [showDemo, setShowDemo] = useState(false);
-  const [currentMode, setCurrentMode] = useState<Mode>(MODES[0]);
   const paletteRefs = useRef<HTMLDivElement[]>([]);
+
+  // Read current mode and version from URL or use defaults
+  const currentMode: Mode = (searchParams.get("output") as Mode) || MODES[0];
+  const currentVersion: Version =
+    (searchParams.get("version") as Version) || VERSIONS[0];
+
+  // Helper functions to update URL parameters
+  const updateMode = (mode: Mode) => {
+    const newParams = new URLSearchParams(searchParams);
+    newParams.set("output", mode);
+    navigate(`${location.pathname}?${newParams.toString()}`, {
+      replace: true,
+      preventScrollReset: true,
+    });
+  };
+
+  const updateVersion = (version: Version) => {
+    const newParams = new URLSearchParams(searchParams);
+    newParams.set("version", version);
+    navigate(`${location.pathname}?${newParams.toString()}`, {
+      replace: true,
+      preventScrollReset: true,
+    });
+  };
 
   // Update meta and URL on any palette state change
   useEffect(() => {
@@ -125,7 +152,9 @@ export default function Generator({ palettes, about, stars }: GeneratorProps) {
             <Output
               palettes={palettesState}
               currentMode={currentMode}
-              setCurrentMode={setCurrentMode}
+              setCurrentMode={updateMode}
+              currentVersion={currentVersion}
+              setCurrentVersion={updateVersion}
             />
           </div>
         </div>

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -1,6 +1,6 @@
 import { CodeBracketIcon, LinkIcon } from "@heroicons/react/24/outline";
 import { StarIcon } from "@heroicons/react/24/solid";
-import { Link } from "react-router";
+import { Link, useLocation } from "react-router";
 import { useCopyToClipboard } from "usehooks-ts";
 
 import { Button } from "~/components/catalyst/button";
@@ -16,13 +16,8 @@ export default function Header({ stars }: { stars: number }) {
     }
   };
 
-  const handleOpenAPI = () => {
-    if (typeof document !== "undefined") {
-      const currentUrl = new URL(window.location.href);
-      currentUrl.pathname = `api`;
-      window.open(currentUrl.toString(), "_blank");
-    }
-  };
+  const location = useLocation();
+  const apiUrl = `/api` + location.pathname + location.search;
 
   return (
     <header className="fixed z-40 inset-0 bottom-auto bg-white/90 backdrop-blur-lg border-b border-first-100">
@@ -60,7 +55,7 @@ export default function Header({ stars }: { stars: number }) {
             <LinkIcon className="size-4" />
             <span className="sr-only">Copy URL</span>
           </Button>
-          <Button outline onClick={handleOpenAPI}>
+          <Button outline href={apiUrl} target="_blank">
             <CodeBracketIcon className="size-4" />
             <span className="sr-only">API</span>
           </Button>

--- a/app/components/Output.tsx
+++ b/app/components/Output.tsx
@@ -1,6 +1,5 @@
 import { ClipboardDocumentIcon } from "@heroicons/react/24/solid";
 import * as Headless from "@headlessui/react";
-import { useState } from "react";
 import { useCopyToClipboard } from "usehooks-ts";
 
 import { Button } from "~/components/catalyst/button";
@@ -13,14 +12,17 @@ type OutputProps = {
   palettes: PaletteConfig[];
   currentMode: Mode;
   setCurrentMode: (mode: Mode) => void;
+  currentVersion: Version;
+  setCurrentVersion: (version: Version) => void;
 };
 
 export default function Output({
   palettes,
   currentMode,
   setCurrentMode,
+  currentVersion,
+  setCurrentVersion,
 }: OutputProps) {
-  const [currentVersion, setCurrentVersion] = useState<Version>(VERSIONS[0]);
   const [, copy] = useCopyToClipboard();
   const shaped = output(palettes, currentMode);
 
@@ -39,7 +41,7 @@ export default function Output({
           <Headless.RadioGroup
             onChange={(v) => setCurrentVersion(v as Version)}
             name="version"
-            defaultValue={currentVersion}
+            value={currentVersion}
             className="flex gap-3"
           >
             {VERSIONS.map((version) => (
@@ -61,7 +63,7 @@ export default function Output({
           <Headless.RadioGroup
             onChange={(v) => setCurrentMode(v as Mode)}
             name="mode"
-            defaultValue={currentMode}
+            value={currentMode}
             className="flex gap-3"
           >
             {MODES.map((mode) => (

--- a/app/routes/api._index.tsx
+++ b/app/routes/api._index.tsx
@@ -1,12 +1,18 @@
 import { data } from "react-router";
 
 import { output, requestToPalettes } from "~/lib/responses";
+import { MODES } from "~/lib/constants";
+import type { Mode } from "~/types";
 
 import type { Route } from "./+types/api._index";
 
 export const loader = ({ request }: Route.LoaderArgs) => {
   const palettes = requestToPalettes(request.url);
-  const responseString = JSON.stringify(output(palettes));
+
+  const url = new URL(request.url);
+  const outputMode: Mode = (url.searchParams.get("output") as Mode) || MODES[0];
+
+  const responseString = JSON.stringify(output(palettes, outputMode));
 
   return data(responseString, {
     headers: {

--- a/app/routes/api.palette.$hash.tsx
+++ b/app/routes/api.palette.$hash.tsx
@@ -2,10 +2,12 @@ import { data } from "react-router";
 
 import { deserializePalette } from "~/lib/paletteHash";
 import { output } from "~/lib/responses";
+import { MODES } from "~/lib/constants";
+import type { Mode } from "~/types";
 
 import type { Route } from "./+types/api.palette.$hash";
 
-export const loader = ({ params }: Route.LoaderArgs) => {
+export const loader = ({ params, request }: Route.LoaderArgs) => {
   if (!params?.hash) {
     throw new Response(`Not Found`, {
       status: 404,
@@ -20,7 +22,10 @@ export const loader = ({ params }: Route.LoaderArgs) => {
     });
   }
 
-  const responseString = JSON.stringify(output([palette])).replace(
+  const url = new URL(request.url);
+  const outputMode: Mode = (url.searchParams.get("output") as Mode) || MODES[0];
+
+  const responseString = JSON.stringify(output([palette], outputMode)).replace(
     / \/ <alpha-value>/g,
     "",
   );


### PR DESCRIPTION
- Replace local state with URL query parameters for Tailwind version and color mode
- Change 'mode' parameter to 'output' for better API clarity
- Update API routes to support output parameter (?output=hex|oklch|hsl|p-3)
- Fix pathname preservation when updating query parameters
- Prevent scroll reset when changing radio button selections
- Update API button to include current path and query parameters

🤖 Generated with [Claude Code](https://claude.ai/code)